### PR TITLE
Switch from dotenv to dotenvy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,10 +220,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -876,7 +876,7 @@ checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 name = "ua_generator"
 version = "0.5.13"
 dependencies = [
- "dotenv",
+ "dotenvy",
  "fastrand",
  "serde",
  "serde_json",

--- a/ua_generator/Cargo.toml
+++ b/ua_generator/Cargo.toml
@@ -20,4 +20,4 @@ ureq = { version = "2.10", features = ["json", "charset", "brotli"] }
 serde = { version = "1", features = ["derive"] }
 serde_json =  { version = "1" }
 toml =  { version = "0" }
-dotenv = "0.15.0"
+dotenvy = "0.15.0"

--- a/ua_generator/build.rs
+++ b/ua_generator/build.rs
@@ -1,7 +1,7 @@
 extern crate serde;
 extern crate ureq;
 
-use dotenv::{dotenv, var};
+use dotenvy::{dotenv, var};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
The dotenv crate is subject to Rustsec advisory RUSTSEC-2021-0141 for being unmaintained.  The dotenvy crate is a supported fork.

https://rustsec.org/advisories/RUSTSEC-2021-0141

To be clear - I know of no actual vulnerability in dotenv, but this does cause a warning in `cargo audit` and I'm just being a little bit of a completionist in burning this number down to 0.