### PR TITLE
Support dispatch on `FormFactor` in `spoof_by`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "ua_generator"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "dotenvy",
  "fastrand",

--- a/ua_generator/Cargo.toml
+++ b/ua_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ua_generator"
-version = "0.5.42"
+version = "0.5.43"
 edition = "2021"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "Random User Agent Spoofer in Rust."

--- a/ua_generator/src/lib.rs
+++ b/ua_generator/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //!
 //! - **Generate** get a random UA to use.
-//!   - [`spoof_ua`]: ua/fn.spoof_ua.html
+//!   - [`spoof_ua`][]: ua/fn.spoof_ua.html
 //!
 //! # Basic usage
 //!

--- a/ua_generator/src/ua.rs
+++ b/ua_generator/src/ua.rs
@@ -564,7 +564,7 @@ mod tests {
         assert!(
             Rc::ptr_eq(
                 agent3_rc,
-                &ua_instance
+                ua_instance
                     .list_map
                     .iter()
                     .find_map(|(rc, _)| if **rc == "Agent3" { Some(rc) } else { None })

--- a/ua_generator/src/ua.rs
+++ b/ua_generator/src/ua.rs
@@ -107,6 +107,43 @@ pub fn spoof_chrome_linux_ua_with_randomizer(thread_rng: &mut Rng) -> &'static s
     pick_rand(Some(thread_rng), STATIC_CHROME_LINUX_AGENTS)
 }
 
+/// Desktop agents.
+pub fn desktop_agents() -> &'static [&'static str] {
+    let v = [
+        STATIC_CHROME_WINDOWS_AGENTS,
+        STATIC_CHROME_MAC_AGENTS,
+        STATIC_CHROME_LINUX_AGENTS,
+        STATIC_FIREFOX_WINDOWS_AGENTS,
+        STATIC_FIREFOX_MAC_AGENTS,
+        STATIC_FIREFOX_LINUX_AGENTS,
+        STATIC_SAFARI_MAC_AGENTS,
+    ]
+    .concat();
+    Box::leak(v.into_boxed_slice())
+}
+
+/// Mobile agents.
+pub fn mobile_agents() -> &'static [&'static str] {
+    let v = [
+        STATIC_CHROME_MOBILE_AGENTS,
+        STATIC_FIREFOX_MOBILE_AGENTS,
+        STATIC_SAFARI_MOBILE_AGENTS,
+    ]
+    .concat();
+    Box::leak(v.into_boxed_slice())
+}
+
+/// Tablet agents.
+pub fn tablet_agents() -> &'static [&'static str] {
+    let v = [
+        STATIC_CHROME_TABLET_AGENTS,
+        STATIC_FIREFOX_TABLET_AGENTS,
+        STATIC_SAFARI_TABLET_AGENTS,
+    ]
+    .concat();
+    Box::leak(v.into_boxed_slice())
+}
+
 /// Slices for each generated family (zero-copy, no alloc).
 #[inline]
 pub fn chrome_agents() -> &'static [&'static str] {
@@ -367,6 +404,15 @@ pub fn spoof_by(
         // Any Safari fallback → global Safari list
         (_, _, Some(Browser::Safari)) => pick_rand(rng, STATIC_SAFARI_AGENTS),
 
+        // --- FormFactor match only ---
+        // Desktop
+        (_, Some(FormFactor::Desktop), _) => pick_rand(rng, desktop_agents()),
+        // Mobile
+        (_, Some(FormFactor::Mobile), _) => pick_rand(rng, mobile_agents()),
+        // Tablet
+        (_, Some(FormFactor::Tablet), _) => pick_rand(rng, tablet_agents()),
+
+        // --- Fall Back ---
         // IE: until IE lists are generated, fall back to mixed static
         _ => pick_rand(rng, STATIC_AGENTS),
     }
@@ -633,5 +679,10 @@ mod tests {
             Some(Browser::Ie),
             None,
         );
+
+        // FormFactor-only
+        let _ = spoof_by(None, Some(FormFactor::Desktop), None, None);
+        let _ = spoof_by(None, Some(FormFactor::Mobile), None, None);
+        let _ = spoof_by(None, Some(FormFactor::Tablet), None, None);
     }
 }


### PR DESCRIPTION
Support grouping of user agents by form factor, and respective dispatch in `spoof_by`.

Closes #7